### PR TITLE
add sponsors and cfp at home, small updates for neurips

### DIFF
--- a/src/components/CallForPapers/index.js
+++ b/src/components/CallForPapers/index.js
@@ -91,7 +91,7 @@ function CallForPapers(props) {
                     </Grid>
 
                     <Typography variant="body1" className={classes.title}>
-                        The 6th Black in AI Workshop will be held co-located with NeurIPS 2022.
+                        The 7th Black in AI Workshop will be held co-located with NeurIPS 2023.
 
                         We are looking forward to papers in the area of AI, including but not limited to computer
                         vision, deep learning, knowledge reasoning, machine learning, multi-agent systems, natural
@@ -102,22 +102,23 @@ function CallForPapers(props) {
                         We encourage all Black researchers in fields related to AI to submit their work. The paper should
                         involve at least one Black researcher as either a lead or co-author.
 
+                        Black researchers in AI, ML and related application areas (health, agriculture, politics, economics, law etc.) 
+                        are welcome to submit their work. We encourage individuals from Black, African, and Diasporic communities to join us and submit their work.
+                        
+                        <a href="/#/conferences" target="_blank"> Check out more information about submissions and important dates.</a> 
                         {/* The workshop will feature invited talks from prominent researchers and practitioners and a poster session. 
                         We invite all members of the AI community to attend the workshop. Registration for the Workshop: 
                         <a href="https://blackinai-workshop2021.eventbrite.com.br" target="_blank" rel="noopener noreferrer">HERE.</a>
                         <br/>
+                        */}
 
-                        Black researchers in AI, ML and related application areas (health, agriculture, politics, economics, law etc.) 
-                        are welcome to submit their work. We encourage individuals from Black, African, and Diasporic communities to join us and submit their work.
-                        
-                        <a href="/#/conferences" target="_blank"> Check out more information about submissions and important dates.</a> */}
                     </Typography>
                     <ColorButton className={classes.chip} variant="contained" href="/#/workshop/bai2023/">
                         Full Details
                     </ColorButton>
-                    <ColorButton className={classes.chip} variant="contained" href="UPDATE-LINK-HERE">
+                    {/* <ColorButton className={classes.chip} variant="contained" href="UPDATE-LINK-HERE">
                         Workshop Registration
-                    </ColorButton>
+                    </ColorButton> */}
                     {/* <ColorButton className={classes.chip} variant="contained" href="https://nbviewer.org/github/blackinai/blackinai.github.io/blob/4a3923311e72ea0613a1fcfd7472d98782787ff9/bai/src/files/BlackinAI22AcceptedPapers.pdf">
                         BAI 2022 Accepted Papers
                     </ColorButton> */}

--- a/src/components/CommunityValues/index.js
+++ b/src/components/CommunityValues/index.js
@@ -66,8 +66,8 @@ const valueslist = [
         text: 'Black in AI was founded to challenge the status quo.'
     },
     {
-        id: 2, title: '3000',
-        text: 'We’ve grown from a small facebook group to a global movement comprising 3000 community members & allies who believe that more Black people should shape the direction of the field of AI.'
+        id: 2, title: '5000+',
+        text: 'We’ve grown from a small facebook group to a global movement comprising 5000 community members & allies who believe that more Black people should shape the direction of the field of AI.'
     },
     {
         id: 3, title: '10+',

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -48,7 +48,7 @@ function Copyright() {
                 Black in AI
             </Link>{' '}{new Date().getFullYear()}{' '}
             <Typography style={{ color:'#f8f7f7'}} variant="body2" marked="left" gutterBottom>
-                Website develop by <Link color="inherit" href="https://github.com/mirianfsilva">@mirianfsilva</Link>
+                website developed by <Link color="inherit" href="https://github.com/mirianfsilva">@mirianfsilva</Link>
             </Typography>
         </React.Fragment>
     );

--- a/src/components/HomeBody/index.js
+++ b/src/components/HomeBody/index.js
@@ -92,7 +92,7 @@ function HomeBody(props) {
                             and job opportunities, summer schools, or research related discussions.
                         </Typography>
                         <ColorButton className={classes.chip} variant="contained" href="https://docs.google.com/forms/d/1pv34QhQE74gBnDu2xTdLmMNnWykY5tN2wihWIh7mwrQ/viewform?edit_requested=true">
-                            Join Us
+                            Become a member
                         </ColorButton>
                     </Grid>
                     <Container className={classes.cardMedia} style={{ backgroundImage: `url(${image2})` }}>    

--- a/src/components/MembershipBody/index.js
+++ b/src/components/MembershipBody/index.js
@@ -65,11 +65,11 @@ const ColorButton = withStyles((theme) => ({
 
 const valueslist = [
     {
-        id: 1, title: '3000+',
-        text: 'We’ve grown from a small facebook group to a global movement comprising 3000 community members and allies who believe that more Black people should shape the direction of the field of AI.'
+        id: 1, title: '5000+',
+        text: 'We’ve grown from a small facebook group to a global movement comprising 5000+ community members and allies who believe that more Black people should shape the direction of the field of AI.'
     },
     {
-        id: 2, title: '42',
+        id: 2, title: '43+',
         text: 'Total number of countries with Black in AI members.'
     },
 ];

--- a/src/components/SponsorshipBody/index.js
+++ b/src/components/SponsorshipBody/index.js
@@ -86,7 +86,7 @@ function SponsorshipBody(props) {
                                 To learn more, please contact us at sponsorship@blackinai.org. 
                             </Typography>
                             <ColorButton className={classes.chip} variant="contained" href="https://github.com/blackinai/blackinai.github.io/raw/d358ea7c584204b0f0f3a29ca2b6889b81cf3159/bai/src/assets/doc/Black_in_AI_2022_Sponsorship.pdf">
-                                Download our sponsorship brochure
+                                Download our sponsorship offerings
                             </ColorButton>
                         </Grid>
                     </Grid> 

--- a/src/components/Workshops/index.js
+++ b/src/components/Workshops/index.js
@@ -91,7 +91,7 @@ function Workshops(props) {
             img: require('./../../assets/img/general/neworleans_convention_center.jpeg'),
             title: 'Black in AI 2023',
             width: '100%',
-            // url: '/#/workshop/bai2023',
+            url: '/#/workshop/bai2023',
         },
         {
             img: require('./../../assets/img/general/neworleans_convention_center.jpeg'),

--- a/src/pages/BaiWorkshops/BAI2023/GridOfContents.js
+++ b/src/pages/BaiWorkshops/BAI2023/GridOfContents.js
@@ -68,22 +68,22 @@ function GridOfContents(props) {
 
     const workshops = [
         {
-            title: 'Call For Paper & Important Deadlines',
+            title: 'Call For Paper & Important Deadlines SOON',
             width: '33.3%',
-            url: '/#/workshop/bai2023-cfp',
+            // url: '/#/workshop/bai2023-cfp',
         },
         {
-            title: 'Call For Reviewer/Area Chair',
+            title: 'Call For Reviewer/Area Chair SOON',
             width: '33.3%',
             // url: 'https://forms.gle/q1v4kqknELEXLLpr8',
         },
         {
-            title: 'Black in AI Travel Grant Application',
-            width: '33.3%',
+            // title: 'Black in AI Travel Grant Application',
+            // width: '33.3%',
             // url: 'https://forms.gle/4CXkLZk89e1JvTZ66',
         },
         {
-            title: 'Workshop Registration (Hybrid format)',
+            title: 'Workshop Registration (Hybrid format) SOON',
             width: '33.3%',
             // url: 'https://forms.gle/SHdt1Bpy5aBbwpBW9',
         },
@@ -98,8 +98,8 @@ function GridOfContents(props) {
         //     url: 'https://nbviewer.org/github/blackinai/blackinai.github.io/blob/main/bai/src/files/BAI2021AcceptedPapersJointPostersSession.pdf',
         // },
         {
-            title: 'Workshop Program',
-            width: '33.3%',
+            // title: 'Workshop Program - SOON',
+            // width: '33.3%',
            // url: 'https://nbviewer.org/github/blackinai/blackinai.github.io/blob/main/bai/src/files/BAI2022WorkshopSchedule.pdf',
         },
         // {
@@ -112,7 +112,7 @@ function GridOfContents(props) {
     return (
         <Container className={classes.root} component="section">
             <Typography variant="h4" marked="center" align="center" component="h2">
-                The 6th Black in AI Workshop will be held co-located with NeurIPS 2022.
+                The 7th Black in AI Workshop will be held co-located with NeurIPS 2023.
                 The workshop will feature invited talks from prominent researchers and practitioners, 
                 a poster session and a startups showcase. We invite all members of the AI community 
                 to attend the workshop.

--- a/src/pages/BaiWorkshops/BAI2023/Sponsors.js
+++ b/src/pages/BaiWorkshops/BAI2023/Sponsors.js
@@ -120,7 +120,7 @@ function Sponsors(props) {
                 <Grid container spacing={12}>
                     <Grid item xs={12}>
                         <Typography variant="h3" marked="center" align="center" component="h2" className={classes.title}>
-                            2022 Sponsors
+                            2023 Sponsors
                         </Typography>
                     </Grid>
                     <Grid item xs={3} spacing={2}>

--- a/src/pages/BaiWorkshops/BAI2023/index.js
+++ b/src/pages/BaiWorkshops/BAI2023/index.js
@@ -17,7 +17,7 @@ function BAI2021() {
             <Navbar />
             <WorkshopPageHeader src={image}/>
             <GridOfContents/>
-            <Sponsors/>
+            {/* <Sponsors/> */}
             <Footer />
         </ThemeProvider>
     );

--- a/src/pages/Home/index.js
+++ b/src/pages/Home/index.js
@@ -18,14 +18,13 @@ function Home() {
             <Loader />
             <CssBaseline />
             <Navbar/>
-            {/* Uncomment this section below to show at the top of Home page the Call For paper for Neurips 2023 */}
-            {/* <CallForPapers/>  */}
+            <CallForPapers/> 
             <HomeHeader/>
             {/* <Advertising/> */}
             <HomeQuote/>
             <HomeBody/>
             <JoinUs/>
-            {/* <SponsorsHome/> */}
+            <SponsorsHome/>
             <Footer/>
         </ThemeProvider>
     );

--- a/src/posts/Media/PressRoom.md
+++ b/src/posts/Media/PressRoom.md
@@ -1,4 +1,4 @@
-##### Last updated on Feb 04, 2022
+##### Last updated on Jun, 2023
 
 ### Black in AI Community Announcements
 - [Black in AI is looking for its first Executive Director!](http:blackinai.github.io/#/bai-open-position-2022)

--- a/src/posts/baiPrograms/AcademicProgram.md
+++ b/src/posts/baiPrograms/AcademicProgram.md
@@ -1,4 +1,4 @@
-##### Last updated on Sep 24, 2020
+##### Last updated on Jun, 2023
 
 
 **The Black in AI Academic Program** is committed to serving as a resource and supporting Black junior researchers as they apply to graduate programs, navigate graduate school, and enter the postgraduate job market. To that end, we conduct online information sessions, provide scholarships to cover costs related to applications, assign participants to peer and senior mentors, and share crowdsourced documents that demystify application processes.

--- a/src/posts/baiPrograms/Advocacy.md
+++ b/src/posts/baiPrograms/Advocacy.md
@@ -1,4 +1,4 @@
-##### Last updated on March 18, 2021
+##### Last updated on Jun, 2023
 
 **Black in AI’s advocacy has focused on removing barriers faced by Black people around the world in the field of AI. Our advocacy has helped remove the GRE as an admissions requirement by some graduate schools in the US, helped shed light on visa issues that Africans and members of the African diaspora face while attempting to attend major international AI conferences, the lack of presence by international companies on the African continent, and the choice of conference locations that exclude many members of our community.**
 

--- a/src/posts/baiPrograms/EntrepreneurshipProgram.md
+++ b/src/posts/baiPrograms/EntrepreneurshipProgram.md
@@ -1,4 +1,4 @@
-##### Last updated on June 25, 2022
+##### Last updated on Jun, 2023
 
 As of 2021, Black founders in the US [receive](https://about.crunchbase.com/2020-diversity-spotlight-report/) around 2% of venture capital and Black investors [represent 3%](https://www.blckvc.com/) of the professionals in the Venture Capital industry. Through our entrepreneurship program, we aim to contribute to closing this gap by accelerating the success of Black in AI founders working on groundbreaking ventures. 
 

--- a/src/posts/baiPrograms/FinancialSupport.md
+++ b/src/posts/baiPrograms/FinancialSupport.md
@@ -1,4 +1,4 @@
-##### Last updated on March 18, 2021
+##### Last updated on Jun, 2023
 
 *In addition to providing scholarships to cover costs associated with navigating academic programs, Black in AI awards need-based travel grants to attend our annual events including our workshop at the NeruIPS conference, and additional events in other conferences such as [AAAI](https://www.aaai.org/), [CVPR](http://cvpr2021.thecvf.com/), [ACL](https://acl2020.org/), [ICML](https://icml.cc/), [ICLR](https://iclr.cc/), [COLING](https://coling2020.org/) and [FAccT](https://facctconference.org/2021/). Our grants cover flights, accommodation, daily per diems, visa fees, data grants, and registration for the conferences. Since the first Black in AI workshop in 2017, **400+** works from **40+** countries have been presented with over **$1M** given out in travel grants supporting **400+** people. Many members cannot afford to first pay out of pocket and then receive reimbursements. Thus we also make travel arrangements for them including booking airfare and accommodation.*
 

--- a/src/posts/baiPrograms/SummerResearchPrograms.md
+++ b/src/posts/baiPrograms/SummerResearchPrograms.md
@@ -1,4 +1,4 @@
-##### Last updated on March 31, 2021
+##### Last updated on Jun, 2023
 
 *Starting summer of 2021, Black in AI is piloting 2 summer programs, one tailored towards undergraduates, and another one without restrictions for participation. Black in AI is excited to partner with the [Distributed Research Experiences for Undergraduates (DREU) program](https://cra.org/cra-wp/dreu/) and will fund a limited number of summer internships in the summer of 2021. In addition, Black in AI is also partnering with Stanford University to pilot the BlackAIR summer research program, to provide research support, mentorship, and exposure to program participants: [blackairgrant.stanford.edu](https://blackairgrant.stanford.edu). Black women at various stages of AI research experience are encouraged to apply. Program participants will be matched with a research mentor whom they will regularly meet (remotely) for research guidance over the course of the grant, and will get the opportunity to hear speakers from various Computer Science research fields. The 2021 edition of the program will be held remotely.*
 


### PR DESCRIPTION
- sponsors section added at home;
- add pages for neurips 23: cfp, workshop header and section add in the conferences grids;
- small updates on the BAI numbers and descriptions; 
